### PR TITLE
Added argparse `net` option

### DIFF
--- a/dsketch/experiments/imageopt/imageopt.py
+++ b/dsketch/experiments/imageopt/imageopt.py
@@ -384,6 +384,9 @@ def add_shared_args(parser):
                         help="colour learning rate (defaults to --lr if not set)")
     parser.add_argument("--restarts", action='store_true', required=False, default=False,
                         help="reinit params if sigma2 becomes too small")
+    parser.add_argument("--net", type=str, required=False, default="vgg",
+                        help="neural network model")
+
 
 
 def main():
@@ -478,4 +481,4 @@ def main():
 
 if __name__ == "__main__":
     main()
-    
+

--- a/dsketch/experiments/imageopt/imageopt.py
+++ b/dsketch/experiments/imageopt/imageopt.py
@@ -384,9 +384,6 @@ def add_shared_args(parser):
                         help="colour learning rate (defaults to --lr if not set)")
     parser.add_argument("--restarts", action='store_true', required=False, default=False,
                         help="reinit params if sigma2 becomes too small")
-    parser.add_argument("--net", type=str, required=False, default="vgg",
-                        help="neural network model")
-
 
 
 def main():
@@ -481,4 +478,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/dsketch/experiments/shared/args_losses.py
+++ b/dsketch/experiments/shared/args_losses.py
@@ -23,7 +23,8 @@ class _Loss:
 
     @staticmethod
     def add_args(p):
-        pass
+        p.add_argument("--net", help="network for pips [alex or vgg]", type=str, default='vgg', required=False)
+         
 
     def __call__(self, input, target):
         pass
@@ -32,10 +33,6 @@ class _Loss:
 class MSELoss(_Loss):
     def __init__(self, args):
         super().__init__(args)
-
-    @staticmethod
-    def add_args(p):
-        pass
 
     def __call__(self, input, target):
         if self.imagewise:
@@ -46,10 +43,6 @@ class MSELoss(_Loss):
 class BCELoss(_Loss):
     def __init__(self, args):
         super().__init__(args)
-
-    @staticmethod
-    def add_args(p):
-        pass
 
     def __call__(self, input, target):
         if self.imagewise:
@@ -399,6 +392,7 @@ class BlurredMSELoss(_Loss):
 
     @staticmethod
     def add_args(p):
+        _Loss.add_args(p)
         p.add_argument("--blur-sigma", help="sigma for blurring in loss", type=float, default=1.0, required=False)
         p.add_argument("--no-symmetric", help="disable symmetric mode", action='store_false', required=False)
 


### PR DESCRIPTION
Hi, first of all, great article, and thanks for making the code publically available.

I noticed that `imageopt` wasn't working with other loss functions. For example:

```bash
$ imageopt --loss BlurredMSELoss --net vgg --invert --seed 1234 --width 300 --lines 2000 --init-sigma2 1.0 --final-sigma2 1.0 --iters 500 --lr 0.01 --init-raster results/vancouver/init.png --final-raster results/vancouver/final.png --init-pdf results/vancouver/init.pdf --final-pdf results/vancouver/final.pdf --snapshots-path results/vancouver data/vancouver.jpg --snapshots-steps 100 --colour

imageopt: error: unrecognized arguments: --net data/vancouver.jpg
```

The `net` parameter was missing and this PR fix this issue.